### PR TITLE
fix: remove SQL antipattern

### DIFF
--- a/kobocat/onadata/apps/usermodule/views_project.py
+++ b/kobocat/onadata/apps/usermodule/views_project.py
@@ -69,7 +69,7 @@ def get_own_and_partner_orgs_usermodule_users(request):
         if current_user:
             current_user = current_user[0]
         all_organizations = get_recursive_organization_children(current_user.organisation_name,[])
-        user_list = UserModuleProfile.objects.filter(organisation_name__in=all_organizations)
+        user_list = UserModuleProfile.objects.filter(organisation_name__in=all_organizations).select_related("user")
     return user_list
 
 


### PR DESCRIPTION
## Description

I was trying to understand the db connection to see if there are any easy wins to speed up bahis-serve and I found this python line: https://github.com/road86/bahis-serve/blob/427d91bcb1b1838b4d5a2de3804a956bb171becf/kobocat/onadata/apps/usermodule/views_project.py#L223 was causing 1000s of additional SQL requests.

This is an antipattern as described here: https://docs.djangoproject.com/en/1.8/ref/models/querysets/#select-related

relates #1

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] My changes generate no new warnings.
