### PR TITLE
fix: correctly read the debug environ variable

### DIFF
--- a/kobocat/onadata/settings/common.py
+++ b/kobocat/onadata/settings/common.py
@@ -29,7 +29,7 @@ WEB_SERVER = os.environ.get('KOBO_SERVER_HOST')
 FORM_RENDERER_SERVER = os.environ.get('KOBO_RENDERER_HOST')
 WEB_SERVER = os.environ.get('KOBO_SERVER_HOST')
 KOBO_MODULE_URL = os.environ.get('KOBO_SERVER_HOST')
-DEBUG = os.environ.get('DJANGO_DEBUG', False)
+DEBUG = os.environ.get('DJANGO_DEBUG') == 'True'
 
 
 


### PR DESCRIPTION
## Description

Turns out we were reading the DJANGO_DEBUG environment variable, which is a string, and using it in conditions as a boolean. As "False" (the string) is always `True` (the boolean) it meant these conditions were always on - this would have turned the debug toolbar on in prod, so I have fixed this.

## Testing

Local exploratory testing all works fine (by changing the environment variable here: https://github.com/road86/bahis-infra/blob/ff7de95b33028a6037b4c6844122a7a0977b771c/deployment/bahisweb/Dockerfile#L75 ).

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [x] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
