### PR TITLE
Fix rounding time creates duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bulk/
 bahisweb/src/kobocat/onadata/apps/reportsmodule/static/
+**/static
 # Django #
 *.log
 *.pot

--- a/kobocat/onadata/apps/api/tests/viewsets/test_briefcase_api.py
+++ b/kobocat/onadata/apps/api/tests/viewsets/test_briefcase_api.py
@@ -212,7 +212,7 @@ class TestBriefcaseAPI(test_abstract_viewset.TestAbstractViewSet):
         with codecs.open(download_submission_path, encoding='utf-8') as f:
             text = f.read()
             text = text.replace(u'{{submissionDate}}',
-                                instance.date_created.isoformat())
+                                instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z')
             self.assertContains(response, instanceId, status_code=200)
             self.assertMultiLineEqual(response.content, text)
 

--- a/kobocat/onadata/apps/api/viewsets/briefcase_api.py
+++ b/kobocat/onadata/apps/api/viewsets/briefcase_api.py
@@ -220,7 +220,7 @@ class BriefcaseApi(OpenRosaHeadersMixin, mixins.CreateModelMixin,
         submission_xml_root_node.setAttribute(
             'instanceID', u'uuid:%s' % self.object.uuid)
         submission_xml_root_node.setAttribute(
-            'submissionDate', self.object.date_created.isoformat()
+            'submissionDate', self.object.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         )
         data = {
             'submission_data': submission_xml_root_node.toxml(),

--- a/kobocat/onadata/apps/api/viewsets/xform_submission_api.py
+++ b/kobocat/onadata/apps/api/viewsets/xform_submission_api.py
@@ -210,12 +210,15 @@ Here is some example JSON, it would replace `[the JSON]` above:
         context = self.get_serializer_context()
         serializer = SubmissionSerializer(instance, context=context)
 
+        print("XFormSubmissionApi.create")
+        print(instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z')
+
         return Response({
             'formid': instance.xform.id_string,
             'encrypted': instance.xform.encrypted,
             'instanceID': u'uuid:%s' % instance.uuid,
-            'submissionDate': instance.date_created.isoformat(),
-            'markedAsCompleteDate': instance.date_modified.isoformat()},
+            'submissionDate': instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',  # TODO MAKE ME THE SAME AS JS ISOSTRING!
+            'markedAsCompleteDate': instance.date_modified.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'},
                         headers=self.get_openrosa_headers(request),
                         status=status.HTTP_201_CREATED,
                         template_name=self.template_name)

--- a/kobocat/onadata/apps/bh_module/views_forms.py
+++ b/kobocat/onadata/apps/bh_module/views_forms.py
@@ -684,12 +684,8 @@ def system_tabl_sync(request, username):
     Returns:
         [json]: [All instance data submitted after the sync time]
     """
-    last_modified = 'null'
-    where_string = ' '
-
     if request.GET.get('last_modified') is not None:
         last_modified = request.GET.get('last_modified')
-        print(last_modified)
         where_string = " where (extract(epoch from date_modified::timestamp) * 1000)::bigint>" + str(last_modified) + ""
     else:
         last_modified = '0'
@@ -841,7 +837,6 @@ def data_sync_count(request, username):
         4:'basic_info/union',
         5:'basic_info/mouza'
     }
-    last_modified = 'null'
     where_string = ' '
 
     # user = User.objects.get(username=username)

--- a/kobocat/onadata/apps/logger/tests/test_briefcase_api.py
+++ b/kobocat/onadata/apps/logger/tests/test_briefcase_api.py
@@ -197,7 +197,7 @@ class TestBriefcaseAPI(TestBase):
         with codecs.open(download_submission_path, encoding='utf-8') as f:
             text = f.read()
             text = text.replace(u'{{submissionDate}}',
-                                instance.date_created.isoformat())
+                                instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z')
             self.assertContains(response, instanceId, status_code=200)
             self.assertMultiLineEqual(response.content, text)
 

--- a/kobocat/onadata/apps/logger/views.py
+++ b/kobocat/onadata/apps/logger/views.py
@@ -111,8 +111,8 @@ def _submission_response(request, instance):
     data['formid'] = instance.xform.id_string
     data['encrypted'] = instance.xform.encrypted
     data['instanceID'] = u'uuid:%s' % instance.uuid
-    data['submissionDate'] = instance.date_created.isoformat()
-    data['markedAsCompleteDate'] = instance.date_modified.isoformat()
+    data['submissionDate'] = instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
+    data['markedAsCompleteDate'] = instance.date_modified.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
 
     context = RequestContext(request, data)
     t = loader.get_template('submission.xml')
@@ -685,7 +685,7 @@ def view_download_submission(request, username):
     submission_xml_root_node.setAttribute(
         'instanceID', u'uuid:%s' % instance.uuid)
     submission_xml_root_node.setAttribute(
-        'submissionDate', instance.date_created.isoformat()
+        'submissionDate', instance.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     )
     data['submission_data'] = submission_xml_root_node.toxml()
     data['media_files'] = Attachment.objects.filter(instance=instance)

--- a/kobocat/onadata/apps/main/database_utility.py
+++ b/kobocat/onadata/apps/main/database_utility.py
@@ -52,7 +52,7 @@ def decimal_date_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
     elif hasattr(obj, 'isoformat'):
-        return obj.isoformat()
+        return obj.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     else:
         return obj
     raise TypeError

--- a/kobocat/onadata/apps/main/views.py
+++ b/kobocat/onadata/apps/main/views.py
@@ -2318,7 +2318,7 @@ def decimal_date_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
     elif hasattr(obj, 'isoformat'):
-        return obj.isoformat()
+        return obj.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     else:
         return obj
     raise TypeError

--- a/kobocat/onadata/apps/sms_support/parser.py
+++ b/kobocat/onadata/apps/sms_support/parser.py
@@ -156,9 +156,9 @@ def parse_sms_text(xform, identity, text):
         if xlsf_type in ('deviceid', 'subscriberid', 'imei'):
             return NA_VALUE
         elif xlsf_type in ('start', 'end'):
-            return datetime.now().isoformat()
+            return datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         elif xlsf_type == 'today':
-            return date.today().isoformat()
+            return date.today().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         elif xlsf_type == 'phonenumber':
             return identity
         return NA_VALUE

--- a/kobocat/onadata/apps/sms_support/providers/textit.py
+++ b/kobocat/onadata/apps/sms_support/providers/textit.py
@@ -99,7 +99,7 @@ def import_submission_for_form(request, username, id_string):
     sms_identity = request.POST.get('phone', '').strip()
     sms_relayer = request.POST.get('relayer', '').strip()
     sms_text = request.POST.get('text', '').strip()
-    now_time = datetime.datetime.now().isoformat()
+    now_time = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     sent_time = request.POST.get('time', now_time).strip()
 
     try:

--- a/kobocat/onadata/apps/usermodule/views.py
+++ b/kobocat/onadata/apps/usermodule/views.py
@@ -1396,7 +1396,7 @@ def decimal_date_default(obj):
     if isinstance(obj, decimal.Decimal):
         return float(obj)
     elif hasattr(obj, 'isoformat'):
-        return obj.isoformat()
+        return obj.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     else:
         return obj
     raise TypeError

--- a/kobocat/onadata/libs/serializers/data_serializer.py
+++ b/kobocat/onadata/libs/serializers/data_serializer.py
@@ -101,6 +101,6 @@ class SubmissionSerializer(serializers.Serializer):
             'formid': obj.xform.id_string,
             'encrypted': obj.xform.encrypted,
             'instanceID': u'uuid:%s' % obj.uuid,
-            'submissionDate': obj.date_created.isoformat(),
-            'markedAsCompleteDate': obj.date_modified.isoformat()
+            'submissionDate': obj.date_created.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z',
+            'markedAsCompleteDate': obj.date_modified.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
         }

--- a/kobocat/onadata/libs/utils/csv_import.py
+++ b/kobocat/onadata/libs/utils/csv_import.py
@@ -77,7 +77,7 @@ def submit_csv(username, xform, csv_file):
 
     csv_reader = ucsv.DictReader(csv_file)
     rollback_uuids = []
-    submission_time = datetime.utcnow().isoformat()
+    submission_time = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'
     ona_uuid = {'formhub': {'uuid': xform.uuid}}
     error = None
     additions = inserts = 0


### PR DESCRIPTION
## Description

Okay, so this is one of three PRs needed to (hopefully!) fix the data duplication issues.

Basically, this one makes Python format ISO dates the same was a JavaScript does... I know, right?! The whole point of a flubbing standard is so that I don't have to do crap like this! But... because... humans... it turns out the JavaScript Date prototype and the Python datetime class... do ISO differently!

closes road86/project-bahis#110
closes road86/project-bahis#145
closes #17
relates road86/bahis-desk#issue_number

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
