### PR TITLE
feat: save bahis version number

### DIFF
--- a/kobocat/onadata/apps/bh_module/migrations/0001_initial.py
+++ b/kobocat/onadata/apps/bh_module/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='DeskVersion',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('desk_version', models.CharField(max_length=20)),
+                ('instance_id', models.IntegerField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'db_table': 'desk_version',
+            },
+        ),
+    ]

--- a/kobocat/onadata/apps/bh_module/models.py
+++ b/kobocat/onadata/apps/bh_module/models.py
@@ -1,0 +1,15 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+class DeskVersion(models.Model):
+    user = models.ForeignKey(User)
+    desk_version = models.CharField(max_length=20)
+    instance_id = models.IntegerField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table="desk_version"
+
+
+    def __str__(self):
+        return self.desk_version

--- a/kobocat/onadata/apps/bh_module/views_forms.py
+++ b/kobocat/onadata/apps/bh_module/views_forms.py
@@ -19,6 +19,7 @@ from onadata.apps.bh_module.utility_functions import datasource_query_generate
 from onadata.apps.logger.models import Instance,XForm
 from onadata.apps.main.database_utility  import __db_fetch_values_dict,__db_fetch_values,__db_fetch_single_value,__db_commit_query,__db_insert_query
 from onadata.apps.usermodule.models import UserRoleMap, UserFailedLogin, UserBranch
+from onadata.apps.bh_module.models import DeskVersion
 
 datasource_type = [['2', 'Datasource'], ['1', 'Table']]
 
@@ -646,6 +647,9 @@ def submission_request(request, username):
 
         instance_data = instance_data.replace('uuid:', '')
         instance = Instance.objects.filter(uuid=instance_data).first()
+        user = User.objects.get(username = username)
+        bahis_no = request.GET['bahis_desk_version']
+        DeskVersion.objects.create(user=user, desk_version=bahis_no, instance_id=instance.id)
         message['id'] = instance.id
         message['date_created'] = instance.date_created.strftime("%Y-%m-%d %H:%M:%S")
 

--- a/kobocat/onadata/apps/usermodule/models.py
+++ b/kobocat/onadata/apps/usermodule/models.py
@@ -118,7 +118,7 @@ class UserRoleMap(models.Model):
 
 #branch
 class Branch(models.Model):
-    id = models.BigIntegerField(null=False)
+    # id = models.BigIntegerField(null=False)
     branch_name = models.CharField(max_length=150)
     organization = models.ForeignKey('Organizations', blank=True, null=True, related_name='org',
                                             on_delete=models.PROTECT)


### PR DESCRIPTION
BAHIS desktop application version number will save while syncing. It will also save syncing time, the instance id of the form, and the user id of the user in the table.

## Description

The purpose of this update is to track BAHIS desk versions used in the field, ensuring the proper functioning of the auto-update feature. For this, the BAHIS desk version number needs to save in the database.

- A new model has been implemented with the following columns:
1.  id
2. desk_version
3. instance_id
4. created_at
5. user_id

- The field will now be automatically populated during the synchronization process. 
- There will be a new entry for each instance of the form.

closes #23 


## Database Changes 

One table will be added to the database in `public` schema named `desk_vesion`. Django migration command needs to be done to create the table.

## Checklist

- [x] I have read the road86 Contribution Guide.
- [x] I have checked all commit message styles match the requested structure.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes generate no new warnings.
- [x] I have made corresponding changes to the documentation.
- [x] New database changes have been committed.
